### PR TITLE
Fix missing children when used with preact-compat

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+// To test using preact, uncomment the following block
+/*
+  resolve: {
+		alias: {
+			react: 'preact-compat',
+			'react-dom': 'preact-compat',
+		},
+	},
+*/
+};

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.18.0",
+    "preact": "^7.1.0",
+    "preact-compat": "^3.9.4",
     "react": "^15.4.1",
     "react-dom": "^15.4.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,6 @@ export default {
       mustProvideAllProps,
     } = options
 
-    const propsCombinations = combinations(possibleValuesByPropName)
-
     this.add(storyName, () => {
       if (mustProvideAllProps) {
         const err = checkForMissingProps(component, possibleValuesByPropName)
@@ -54,6 +52,8 @@ export default {
           return <ErrorDisplay message={err.message} />
         }
       }
+
+      const propsCombinations = combinations(possibleValuesByPropName)
 
       return (
         <div>


### PR DESCRIPTION
This PR fixes an issue which appears when using `preact` and `preact-compat`. For some reason, the `children` key gets removed from `props`, so the components are rendered empty.