### PR TITLE
Full Preact compatiblity

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,14 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.18.0",
+    "preact": "^7.1.0",
+    "preact-compat": "^3.9.4",
     "react": "^15.4.1",
     "react-dom": "^15.4.1"
   },
   "dependencies": {
     "object-hash": "^1.1.5",
-    "react-element-to-jsx-string": "^5.0.2"
+    "pretty-format": "^18.1.0"
   },
   "peerDependencies": {
     "react": "^0.14.7 || ^15.0.0"

--- a/src/CombinationRenderer.js
+++ b/src/CombinationRenderer.js
@@ -1,5 +1,24 @@
 import React from 'react';
-import reactElementToJSXString from 'react-element-to-jsx-string';
+import prettyFormat from 'pretty-format';
+import reactElementPlugin from 'pretty-format/build/plugins/ReactElement';
+
+const reactElement = Symbol.for('react.element');
+
+const transformPreactElement = (el) => {
+  if (!el.preactCompatUpgraded) {
+    return el;
+  }
+  el.props = {
+    ...el.attributes,
+    children: el.children.map(child => {
+      if (child.$$typeof === reactElement) {
+        return transformPreactElement(child);
+      }
+      return child;
+    }),
+  };
+  return el;
+};
 
 export default ({Component, props, options}) => {
   const el = React.createElement(Component, props)
@@ -13,7 +32,9 @@ export default ({Component, props, options}) => {
       {el}
       {showSource && (
         <pre>
-          {reactElementToJSXString(el)}
+          {prettyFormat(transformPreactElement(el), {
+            plugins: [reactElementPlugin],
+          })}
         </pre>
       )}
     </div>

--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,6 @@ export default {
       mustProvideAllProps,
     } = options
 
-    const propsCombinations = combinations(possibleValuesByPropName)
-
     this.add(storyName, () => {
       if (mustProvideAllProps) {
         const err = checkForMissingProps(component, possibleValuesByPropName)
@@ -54,6 +52,8 @@ export default {
           return <ErrorDisplay message={err.message} />
         }
       }
+
+      const propsCombinations = combinations(possibleValuesByPropName)
 
       return (
         <div>


### PR DESCRIPTION
This PR adds full compatibility for using this addon together with `preact` and `preact-compat`, instead of `react`.

1. For some reason, the `children` key gets removed from `props`, so the components are rendered empty.
2. The `react-element-to-jsx-string` package does not support the `preact` data structure. Replaced this with the `pretty-format` (used in `jest`) which supports the `preact` data structure with a small transformation step. This solves the source output.

This PR also includes the changes in https://github.com/evgenykochetkov/react-storybook-addon-props-combinations/pull/10